### PR TITLE
Upgrade Log4js 2.x and use npm audit on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,12 @@
+defaults: &defaults
+  docker:
+    - image: circleci/node:10.6
+  working_directory: ~/repo
+
 version: 2
 jobs:
   build:
-    docker:
-      - image: circleci/node:10.6
-    working_directory: ~/repo
+    <<: *defaults
     steps:
       - checkout
 
@@ -53,3 +56,32 @@ jobs:
           destination: reports
       - store_test_results:
           path: reports/junit
+      - persist_to_workspace:
+          root: ~/repo
+          paths: .
+
+  deploy:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/repo
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/repo/.npmrc
+      - run:
+          name: Publish package
+          command: npm publish
+
+workflows:
+  version: 2
+  build-deploy:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
             ./ci-tools/codeclimate-reporter sum-coverage ci-tools/codeclimate.json -p $CIRCLE_NODE_TOTAL -o ci-tools/codeclimate.total.json
             ./ci-tools/codeclimate-reporter upload-coverage -i ci-tools/codeclimate.total.json
 
-      # - run: npm audit # enable when log4js audits successfully with loggly
+      - run: npm audit # enable when log4js audits successfully with loggly
 
       - store_artifacts:
           path: coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+.circleci
+.github
+coverage
+reports
+.eslint.json
+.editorconfig
+.babelrc
+*.test.js
+jest.*
+yarn.lock
+*.log
+*.tgz

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log4js-sumologic-appender",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple log4js appender for SumoLogic",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "babel-preset-es2015": "^6.24.1",
     "jest": "^23.2.0",
     "jest-junit": "^3.6.0",
-    "log4js": "^2.10.0"
+    "log4js": "^3.0.2"
   },
   "jest-junit": {
     "output": "./reports/junit/junit.xml"


### PR DESCRIPTION
## Problem / Feature

- Log4js 2.x has security vulnerabilities.
- Add `npm audit` to the CI process


## Solution

- Upgraded Log4js to 3.x
- Added `npm audit` to the CI process

## Areas of Impact

- CI
- Consumers

## Unit Tests

N/A

## Manual Tests

Verify CI passes