### PR TITLE
Publish CI on master (not tags) and require approval

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,9 @@ workflows:
     jobs:
       - build
       - deploy:
+          type: approval
           requires:
             - build
           filters:
-            tags:
-              only: /^v.*/
             branches:
-              ignore: /.*/
+              only: master


### PR DESCRIPTION
## Feature

Instead of publishing on tags (CircleCI has some issues there), we should publish on `master` merges.

## Solution

- Adjust CircleCI workflow to publish on `master` merge

## Areas of Impact

- CI

## Unit Tests

N/A

## Manual Tests

N/A