### PR TITLE
Retrying sending failed logs added

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,6 +2,11 @@
   "presets": [
     [
       '@babel/preset-env',
+      {
+        targets: {
+          node: 'current',
+        },
+      },
     ]
   ]
 }

--- a/README.md
+++ b/README.md
@@ -48,3 +48,18 @@ $ yarn add log4js-sumologic-appender
 ```
 
 See [example](example/) for a working example.
+
+#### Error handling
+
+In case requests to Sumo Logic fail, appender performs up to 10 retries. To override the default value for the number of retries add a `maxRetryCount` property to Sumo Logic appender config:
+
+``` js
+  sumologic: {
+    type: 'log4js-sumologic-appender',
+    endpoint: 'http://sumo/endpoint/here',
+    maxRetryCount: 5,
+    ...
+  }
+```
+
+If none of the retries are completed successfully, an error message will be written to stderr. 

--- a/index.js
+++ b/index.js
@@ -1,28 +1,30 @@
 'use strict';
 
 const name = 'log4js-sumologic-appender';
+const maxRetryCountDefaultValue = 10;
 
 const appender = (config, layout) => {
   return (logEvent) => {
     const SumoLogger = require('sumo-logger');
+    const maxRetryCount = config.maxRetryCount || maxRetryCountDefaultValue;
 
     // Duplicate so we can edit without editing the original
     let sumoConfig = {
       ...config
     };
     delete sumoConfig.type;
+    delete sumoConfig.maxRetryCount;
 
     const sumoLogger = new SumoLogger(sumoConfig);
 
+    let eventToSend;
     if (config.graphite) {
-      sumoLogger.log({
-        ...logEvent.data[0],
-      });
-
-      return;
+      eventToSend = {...logEvent.data[0]};
+    } else {
+      eventToSend = layout ? layout(logEvent, config.timezoneOffset) : logEvent;
     }
-
-    sumoLogger.log(layout ? layout(logEvent, config.timezoneOffset) : logEvent);
+    return sendEvent(sumoLogger, eventToSend, maxRetryCount)
+      .catch(error => console.error('Sending event to Sumo Logic failed: ' + error + ', event: ' + eventToSend));
   };
 };
 
@@ -40,8 +42,19 @@ const configure = (config, layouts) => {
   return appender(config, layout);
 };
 
+const sendEvent = (sumoLogger, event, maxRetryCount, retryCount = 1) => {
+  return sumoLogger.log(event)
+    .catch(error => {
+      if (retryCount >= maxRetryCount) {
+        return Promise.reject(error);
+      }
+
+      return sendEvent(sumoLogger, event, maxRetryCount, retryCount + 1);
+    });
+};
+
 module.exports = {
   name,
   appender,
   configure,
-}
+};

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,8 @@
-jest.mock('sumo-logger');
+const mockLog = jest.fn(() => Promise.resolve());
+
+const mock = jest.fn().mockImplementation(() => {
+  return {log: mockLog};
+});
+mock.prototype.log = mockLog;
+
+jest.mock('sumo-logger', () => mock);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log4js-sumologic-appender",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A simple log4js appender for SumoLogic",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "log4js-sumologic-appender",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "A simple log4js appender for SumoLogic",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Problem / Feature
In the current implementation, if sending logs to Sumo Logic fails, the following error message is returned: 

```
(node:22) UnhandledPromiseRejectionWarning: Error: Request failed with status code 502
    at createError (/usr/app/node_modules/axios/lib/core/createError.js:16:15)
    at settle (/usr/app/node_modules/axios/lib/core/settle.js:18:12)
    at IncomingMessage.handleStreamEnd (/usr/app/node_modules/axios/lib/adapters/http.js:201:11)
    at emitNone (events.js:111:20)
    at IncomingMessage.emit (events.js:208:7)
    at endReadableNT (_stream_readable.js:1064:12)
    at _combinedTickCallback (internal/process/next_tick.js:138:11)
    at process._tickDomainCallback (internal/process/next_tick.js:218:9)
    at process.wrappedFunction (/usr/app/node_modules/newrelic/lib/transaction/tracer/index.js:276:51)","Time":********,"Host":"*****","Category":"*****","Name":"Http Input","Collector":"******"}]      
```

This happens because a promise that `sumoLogger.log(event)` function returns is ignored. 

## Solution
Add logic to retry sending logs if the initial request fails. If sending logs fails after a specified number of retries, write an error message to stderr.

## Areas of Impact

A process of sending logs to Sumo Logic.

## Unit Tests

<img width="532" alt="Screen Shot 2019-05-29 at 11 24 40 AM" src="https://user-images.githubusercontent.com/23524427/58542185-c13da200-8205-11e9-95af-9855d6d63832.png">

## Manual Tests

- Verify CI runs